### PR TITLE
Stabilize cookie modal visibility handling

### DIFF
--- a/en/index.html
+++ b/en/index.html
@@ -452,17 +452,17 @@ All rates are excluding VAT. Invoicing country is Portugal, so the applicable VA
       <a href="/cookie-policy.en.html">Cookie Policy</a>.
     </p>
     <div class="cookie-buttons">
-      <button id="cookie-accept">Accept All</button>
-      <button id="cookie-manage">Manage Preferences</button>
+      <button id="cookie-accept" type="button">Accept All</button>
+      <button id="cookie-manage" type="button">Manage Preferences</button>
     </div>
   </div>
 </div>
 
 <!-- Cookie Preferences Modal -->
-<div id="cookie-modal" class="hidden">
+<div id="cookie-modal" role="dialog" aria-modal="true" aria-labelledby="cookie-modal-title" aria-hidden="true">
   <div class="cookie-modal-content">
-    <button id="cookie-close-modal" class="cookie-close" aria-label="Close">&times;</button>
-    <h3>Manage Cookie Preferences</h3>
+    <button id="cookie-close-modal" class="cookie-close" type="button" aria-label="Close">&times;</button>
+    <h3 id="cookie-modal-title">Manage Cookie Preferences</h3>
     <form id="cookie-form">
       <label>
         <input type="checkbox" checked disabled>

--- a/index.html
+++ b/index.html
@@ -452,17 +452,17 @@ All rates are excluding VAT. Invoicing country is Portugal, so the applicable VA
       <a href="/cookie-policy.en.html">Cookie Policy</a>.
     </p>
     <div class="cookie-buttons">
-      <button id="cookie-accept">Accept All</button>
-      <button id="cookie-manage">Manage Preferences</button>
+      <button id="cookie-accept" type="button">Accept All</button>
+      <button id="cookie-manage" type="button">Manage Preferences</button>
     </div>
   </div>
 </div>
 
 <!-- Cookie Preferences Modal -->
-<div id="cookie-modal" class="hidden">
+<div id="cookie-modal" role="dialog" aria-modal="true" aria-labelledby="cookie-modal-title" aria-hidden="true">
   <div class="cookie-modal-content">
-    <button id="cookie-close-modal" class="cookie-close" aria-label="Close">&times;</button>
-    <h3>Manage Cookie Preferences</h3>
+    <button id="cookie-close-modal" class="cookie-close" type="button" aria-label="Close">&times;</button>
+    <h3 id="cookie-modal-title">Manage Cookie Preferences</h3>
     <form id="cookie-form">
       <label>
         <input type="checkbox" checked disabled>

--- a/ru/index.html
+++ b/ru/index.html
@@ -576,29 +576,29 @@
       <a href="/cookie-policy.ru.html">Политика cookie</a>.
     </p>
     <div class="cookie-buttons">
-      <button id="cookie-accept">Принять все</button>
-      <button id="cookie-manage">Управлять настройками</button>
+      <button id="cookie-accept" type="button">Принять все</button>
+      <button id="cookie-manage" type="button">Управлять настройками</button>
     </div>
   </div>
 </div>
 
 <!-- Cookie Preferences Modal -->
-<div id="cookie-modal" class="hidden">
+<div id="cookie-modal" role="dialog" aria-modal="true" aria-labelledby="cookie-modal-title" aria-hidden="true">
   <div class="cookie-modal-content">
-    <button id="cookie-close-modal" class="cookie-close" aria-label="Close">&times;</button>
-    <h3>Управление настройками cookie</h3>
+    <button id="cookie-close-modal" class="cookie-close" type="button" aria-label="Close">&times;</button>
+    <h3 id="cookie-modal-title">Управление настройками cookie</h3>
     <form id="cookie-form">
       <label>
         <input type="checkbox" checked disabled />
-        <strong>Строго необходимые cookie</strong> (Всегда активны)
+        <span><strong>Строго необходимые cookie</strong> (Всегда активны)</span>
       </label>
       <label>
         <input type="checkbox" id="analytics-cookies" />
-        Cookie для аналитики и производительности
+        <span>Cookie для аналитики и производительности</span>
       </label>
       <label>
         <input type="checkbox" id="marketing-cookies" />
-        Маркетинговые cookie
+        <span>Маркетинговые cookie</span>
       </label>
       <div class="cookie-modal-actions">
         <button type="submit">Сохранить настройки</button>

--- a/script.js
+++ b/script.js
@@ -230,6 +230,8 @@ window.addEventListener('load', () => {
   }
 });
 
+let hideCookieModalFn;
+
 // ===== COOKIE CONSENT FUNCTIONALITY =====
 document.addEventListener("DOMContentLoaded", () => {
   const banner = document.getElementById("cookie-banner");
@@ -241,19 +243,94 @@ document.addEventListener("DOMContentLoaded", () => {
   const analyticsInput = document.getElementById("analytics-cookies");
   const marketingInput = document.getElementById("marketing-cookies");
 
-  if (!banner) return; // Exit if cookie banner doesn't exist
+  if (!banner || !modal || !form) return; // Exit if cookie elements don't exist
 
-  // Save preferences
-  function savePreferences(prefs) {
-    localStorage.setItem("cookie-preferences", JSON.stringify(prefs));
-    console.log("Cookie preferences saved:", prefs);
-  }
+  const COOKIE_PREF_KEY = "cookie-preferences";
+  let lastFocusedElement = null;
 
-  // Check if preferences exist
-  const savedPrefs = localStorage.getItem("cookie-preferences");
-  if (!savedPrefs) {
+  const readPreferences = () => {
+    try {
+      const stored = localStorage.getItem(COOKIE_PREF_KEY);
+      if (!stored) return null;
+      return JSON.parse(stored);
+    } catch (error) {
+      console.warn("Unable to read stored cookie preferences", error);
+      localStorage.removeItem(COOKIE_PREF_KEY);
+      return null;
+    }
+  };
+
+  let currentPrefs = readPreferences();
+
+  const syncFormState = (prefs) => {
+    if (analyticsInput) analyticsInput.checked = !!(prefs?.analytics);
+    if (marketingInput) marketingInput.checked = !!(prefs?.marketing);
+  };
+
+  const toggleBodyScroll = (shouldLock) => {
+    document.body.classList.toggle("cookie-modal-open", shouldLock);
+  };
+
+  const showBanner = () => {
     banner.classList.remove("hidden");
     banner.style.display = "flex";
+  };
+
+  const hideBanner = () => {
+    banner.classList.add("hidden");
+    banner.style.display = "none";
+  };
+
+  const focusElement = (element) => {
+    if (!element || !(element instanceof HTMLElement) || !element.isConnected) {
+      return;
+    }
+
+    try {
+      element.focus({ preventScroll: true });
+    } catch (error) {
+      element.focus();
+    }
+  };
+
+  const showModal = () => {
+    lastFocusedElement = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    currentPrefs = readPreferences() || currentPrefs;
+    syncFormState(currentPrefs);
+    modal.classList.add("is-visible");
+    modal.setAttribute("aria-hidden", "false");
+    toggleBodyScroll(true);
+    focusElement(closeModalBtn);
+  };
+
+  const hideModal = () => {
+    if (!modal.classList.contains("is-visible")) {
+      return;
+    }
+
+    modal.classList.remove("is-visible");
+    modal.setAttribute("aria-hidden", "true");
+    toggleBodyScroll(false);
+    focusElement(lastFocusedElement);
+    lastFocusedElement = null;
+  };
+
+  hideCookieModalFn = hideModal;
+
+  const savePreferences = (prefs) => {
+    try {
+      localStorage.setItem(COOKIE_PREF_KEY, JSON.stringify(prefs));
+      currentPrefs = prefs;
+      console.log("Cookie preferences saved:", prefs);
+    } catch (error) {
+      console.error("Failed to persist cookie preferences", error);
+    }
+  };
+
+  if (!currentPrefs) {
+    showBanner();
+  } else {
+    syncFormState(currentPrefs);
   }
 
   // Accept all cookies
@@ -263,44 +340,36 @@ document.addEventListener("DOMContentLoaded", () => {
       analytics: true,
       marketing: true
     });
-    banner.classList.add("hidden");
-    banner.style.display = "none";
+    hideBanner();
+    hideModal();
   });
 
   // Open preferences modal
   manageBtn?.addEventListener("click", () => {
-    modal?.classList.remove("hidden");
-    
-    // Load current preferences
-    if (savedPrefs) {
-      const prefs = JSON.parse(savedPrefs);
-      if (analyticsInput) analyticsInput.checked = prefs.analytics || false;
-      if (marketingInput) marketingInput.checked = prefs.marketing || false;
-    }
+    showModal();
   });
 
   // Close modal
   closeModalBtn?.addEventListener("click", () => {
-    modal?.classList.add("hidden");
+    hideModal();
   });
 
   // Save selected preferences
-  form?.addEventListener("submit", (e) => {
+  form.addEventListener("submit", (e) => {
     e.preventDefault();
     savePreferences({
       essential: true,
-      analytics: analyticsInput?.checked || false,
-      marketing: marketingInput?.checked || false
+      analytics: !!analyticsInput?.checked,
+      marketing: !!marketingInput?.checked
     });
-    modal?.classList.add("hidden");
-    banner.classList.add("hidden");
-    banner.style.display = "none";
+    hideModal();
+    hideBanner();
   });
 
   // Close modal on overlay click
-  modal?.addEventListener("click", (e) => {
+  modal.addEventListener("click", (e) => {
     if (e.target === modal) {
-      modal.classList.add("hidden");
+      hideModal();
     }
   });
 });
@@ -412,8 +481,14 @@ document.addEventListener('keydown', (e) => {
     
     // Close cookie modal
     const cookieModal = document.getElementById('cookie-modal');
-    if (cookieModal && !cookieModal.classList.contains('hidden')) {
-      cookieModal.classList.add('hidden');
+    if (cookieModal && cookieModal.classList.contains('is-visible')) {
+      if (typeof hideCookieModalFn === 'function') {
+        hideCookieModalFn();
+      } else {
+        cookieModal.classList.remove('is-visible');
+        cookieModal.setAttribute('aria-hidden', 'true');
+        document.body.classList.remove('cookie-modal-open');
+      }
     }
   }
 });

--- a/styles.css
+++ b/styles.css
@@ -869,6 +869,7 @@ a {
 
 /* ===== COOKIE MODAL ===== */
 #cookie-modal {
+  display: none;
   position: fixed;
   top: 0;
   left: 0;
@@ -876,18 +877,12 @@ a {
   height: 100%;
   background: rgba(10, 10, 10, 0.85);
   z-index: 3000;
-  overflow-y: auto;
   padding: 20px;
 }
 
-#cookie-modal.hidden {
-  display: none;
-}
-
-#cookie-modal:not(.hidden) {
-  display: flex;
-  align-items: center;
-  justify-content: center;
+#cookie-modal.is-visible {
+  display: grid;
+  place-items: center;
 }
 
 #cookie-modal .cookie-modal-content {
@@ -900,6 +895,7 @@ a {
   width: 90%;
   max-height: 90vh;
   overflow-y: auto;
+  box-shadow: 0 24px 48px rgba(9, 16, 40, 0.35);
 }
 
 #cookie-modal .cookie-modal-content h3 {
@@ -948,6 +944,7 @@ a {
   height: 18px;
   cursor: pointer;
   flex-shrink: 0;
+  accent-color: #f90;
 }
 
 #cookie-modal .cookie-modal-content input[type="checkbox"]:disabled {
@@ -994,6 +991,10 @@ a {
 
 #cookie-modal .cookie-close:hover {
   color: #000;
+}
+
+body.cookie-modal-open {
+  overflow: hidden;
 }
 
 /* ===== OVERLAY ДЛЯ МОБИЛЬНОГО МЕНЮ ===== */

--- a/uk/index.html
+++ b/uk/index.html
@@ -489,29 +489,29 @@
       <a href="/cookie-policy.uk.html">Політика щодо cookie</a>.
     </p>
     <div class="cookie-buttons">
-      <button id="cookie-accept">Прийняти усі</button>
-      <button id="cookie-manage">Керування налаштуваннями</button>
+      <button id="cookie-accept" type="button">Прийняти усі</button>
+      <button id="cookie-manage" type="button">Керування налаштуваннями</button>
     </div>
   </div>
 </div>
 
 <!-- Cookie Preferences Modal -->
-<div id="cookie-modal" class="hidden">
+<div id="cookie-modal" role="dialog" aria-modal="true" aria-labelledby="cookie-modal-title" aria-hidden="true">
   <div class="cookie-modal-content">
-    <button id="cookie-close-modal" class="cookie-close" aria-label="Close">&times;</button>
-    <h3>Керування налаштуваннями файлів cookie</h3>
+    <button id="cookie-close-modal" class="cookie-close" type="button" aria-label="Close">&times;</button>
+    <h3 id="cookie-modal-title">Керування налаштуваннями файлів cookie</h3>
     <form id="cookie-form">
       <label>
         <input type="checkbox" checked disabled />
-        <strong>Суворо необхідні cookie</strong> (завжди активні)
+        <span><strong>Суворо необхідні cookie</strong> (завжди активні)</span>
       </label>
       <label>
         <input type="checkbox" id="analytics-cookies" />
-        Cookie для продуктивності та аналітики
+        <span>Cookie для продуктивності та аналітики</span>
       </label>
       <label>
         <input type="checkbox" id="marketing-cookies" />
-        Маркетингові cookie
+        <span>Маркетингові cookie</span>
       </label>
       <div class="cookie-modal-actions">
         <button type="submit">Зберегти налаштування</button>


### PR DESCRIPTION
## Summary
- update the cookie modal markup in every landing page locale to drop the `hidden` class and rely on JavaScript to manage visibility
- add a resilient focus helper and `is-visible` toggling so the modal opens consistently and restores focus without leaving stale state behind
- default the modal overlay to `display: none` and show it only when the new state class is applied for predictable rendering in Chrome

## Testing
- python - <<'PY'
from pathlib import Path
files = [Path('index.html'), Path('en/index.html'), Path('ru/index.html'), Path('uk/index.html')]
for file in files:
    html = file.read_text()
    has_hidden = 'id="cookie-modal" class="hidden"' in html
    has_is_visible = 'is-visible' in html
    print(f"{file}: has hidden class -> {has_hidden}, is-visible tokens -> {has_is_visible}")
PY

------
https://chatgpt.com/codex/tasks/task_e_68f40b6fdc008333a421ae110c42fd07